### PR TITLE
use 'group' instead of 'wg', 'wgURI', 'wgPatentURI'

### DIFF
--- a/tt-live-1/spec/tt-live.html
+++ b/tt-live-1/spec/tt-live.html
@@ -15,7 +15,7 @@
           w3cid: "64750",
           mailto: "nigel.megitt@bbc.co.uk",
         }]
-        , group: "timed-text"
+        , group: "wg/timed-text"
         , wgPublicList: "public-tt"
         , subjectPrefix: "[tt-live-1]"
         , edDraftURI: "https://w3c.github.io/tt-module-live/tt-live1/spec/tt-live.html"

--- a/tt-live-1/spec/tt-live.html
+++ b/tt-live-1/spec/tt-live.html
@@ -15,10 +15,8 @@
           w3cid: "64750",
           mailto: "nigel.megitt@bbc.co.uk",
         }]
-        , wg: "Timed Text Working Group"
-        , wgURI: "https://www.w3.org/AudioVideo/TT/"
+        , group: "timed-text"
         , wgPublicList: "public-tt"
-        , wgPatentURI: "https://www.w3.org/2004/01/pp-impl/34314/status"
         , subjectPrefix: "[tt-live-1]"
         , edDraftURI: "https://w3c.github.io/tt-module-live/tt-live1/spec/tt-live.html"
         , github: {

--- a/tt-live-1/spec/tt-live.html
+++ b/tt-live-1/spec/tt-live.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <title>TTML Live Extensions Module v1</title>
     <script
-     src='https://www.w3.org/Tools/respec/respec-w3c-common'
+     src='https://www.w3.org/Tools/respec/respec-w3c'
      class='remove'></script>
     <script class='remove'>
       var respecConfig = {


### PR DESCRIPTION
(for future use)
From [recent respec update](https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html), replace 'wg', 'wgURI', 'wgPatentURI' with 'group': 

> ## `group` configuration option
> 
> With a new configuration option — “group”, you can specify a “shortname” for the WG/CG and let ReSpec figure out the details for you. The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of “group”.

'timed-text' is from [list](https://respec.org/w3c/groups/)